### PR TITLE
Add 'add to calendar' link to future events

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\CalendarLinks\Link;
 
 class Event extends Model
 {
@@ -55,5 +56,36 @@ class Event extends Model
     public function hasSpeaker(int $number): bool
     {
         return ! empty($this->{"speaker_{$number}_name"});
+    }
+
+    public function hasTalkTitle(int $number): bool
+    {
+        return ! empty($this->{"speaker_{$number}_talk_title"});
+    }
+
+    public function talkTitle(int $number): string
+    {
+        return $this->{"speaker_{$number}_talk_title"};
+    }
+
+    public function calendarLink(): \Spatie\CalendarLinks\Link
+    {
+        $from = $this->held_at;
+        $to = $this->held_at->addHour();
+
+        $talkTitles = [];
+
+        if ($this->hasTalkTitle(1)) {
+            $talkTitles[] = $this->talkTitle(1);
+        }
+
+        if ($this->hasTalkTitle(2)) {
+            $talkTitles[] = $this->talkTitle(2);
+        }
+
+        $link = Link::create('Laravel Worldwide Meetup', $from, $to)
+            ->description(implode(PHP_EOL, $talkTitles));
+
+        return $link;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "laravel/horizon": "^4.3",
         "laravel/nova": "^3.6",
         "laravel/tinker": "^2.0",
+        "spatie/calendar-links": "^1.4",
         "spatie/laravel-backup": "^6.11",
         "spatie/laravel-flash": "^1.6",
         "spatie/laravel-honeypot": "^2.2",

--- a/resources/views/components/event-listing.blade.php
+++ b/resources/views/components/event-listing.blade.php
@@ -5,9 +5,11 @@
                 <h3 class="text-lg leading-6 font-medium text-gray-900">
                     {{ $event->held_at->format('F d, Y H:i') }} UTC
                 </h3>
-                <a class="text-sm leading-5 text-gray-500" href="{{ $event->calendarLink()->ics() }}">
-                    add to calendar
-                </a>
+                @unless($event->held_at->isPast())
+                    <a class="text-sm leading-5 text-gray-500" href="{{ $event->calendarLink()->ics() }}">
+                        add to calendar
+                    </a>
+                @endunless
             </div>
             <div class="ml-4 mt-4 flex-shrink-0">
                 @if ($event->youtube_url)

--- a/resources/views/components/event-listing.blade.php
+++ b/resources/views/components/event-listing.blade.php
@@ -5,6 +5,9 @@
                 <h3 class="text-lg leading-6 font-medium text-gray-900">
                     {{ $event->held_at->format('F d, Y H:i') }} UTC
                 </h3>
+                <a class="text-sm leading-5 text-gray-500" href="{{ $event->calendarLink()->ics() }}">
+                    add to calendar
+                </a>
             </div>
             <div class="ml-4 mt-4 flex-shrink-0">
                 @if ($event->youtube_url)

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -36,6 +36,9 @@
                     <h3 class="text-2xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-3xl sm:leading-10">
                         {{ $event->held_at->format('F d, Y H:i') }} UTC
                     </h3>
+                    <a class="text-gray-500" href="{{ $event->calendarLink()->ics() }}">
+                        add to calendar
+                    </a>
                     <p class="mt-3 max-w-2xl mx-auto text-xl leading-7 text-gray-500 sm:mt-4">
                         Join us for a bunch of interesting talks!
                     </p>


### PR DESCRIPTION
Adds a link on the home screen
<img width="516" alt="Bildschirmfoto 2020-07-07 um 10 32 57" src="https://user-images.githubusercontent.com/5311185/86749491-96935f00-c03d-11ea-9eaf-db389f3d6c90.png">


... and for future events on the event listing page
<img width="795" alt="Bildschirmfoto 2020-07-07 um 10 33 19" src="https://user-images.githubusercontent.com/5311185/86749601-aa3ec580-c03d-11ea-94fe-c90541f21888.png">


Please note that I do not have a Nova license. Therefore this pull request does not include an up-to-date composer.lock file