### PR TITLE
Add support for showing the local time of the event

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@tailwindcss/ui": "^0.3.1",
-        "alpine": "^0.2.1",
+        "alpinejs": "^2.6.0",
         "tailwindcss": "^1.4.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dependencies": {
         "@tailwindcss/ui": "^0.3.1",
         "alpinejs": "^2.6.0",
+        "dateformat": "^3.0.3",
         "tailwindcss": "^1.4.6"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,3 @@
 require('./bootstrap');
 
-import 'alpine';
+import 'alpinejs';

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,13 @@
 require('./bootstrap');
 
 import 'alpinejs';
+var dateFormat = require('dateformat');
+
+window.convertUTCDateToLocalDate = function(inputDate) {
+    var date = new Date(inputDate);
+    var newDate = new Date(date.getTime()+date.getTimezoneOffset()*60*1000);
+    newDate.setHours(date.getHours() - (date.getTimezoneOffset() / 60));
+    var timezone = newDate.toLocaleTimeString('en-us',{timeZoneName:'short'}).split(' ')[2];
+
+    return dateFormat(newDate, 'mmmm dd, yyyy HH:MM') + ' ' + timezone;
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -36,8 +36,9 @@
                     <h2 class="text-2xl leading-9 tracking-tight font-extrabold text-gray-600 sm:text-3xl sm:leading-10 mb-2">
                         {{ $event->announcementTitle() }}
                     </h2>
-                    <h3 class="text-2xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-3xl sm:leading-10">
-                        {{ $event->held_at->format('F d, Y H:i') }} UTC
+                    <h3  class="text-2xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-3xl sm:leading-10">
+                        <span x-data x-text="convertUTCDateToLocalDate('{{ $event->held_at }}')"></span>
+                        <div class="text-gray-500 text-lg font-medium">({{ $event->held_at->format('F d, Y H:i') }} UTC)</div>
                     </h3>
                     <p class="mt-3 max-w-2xl mx-auto text-xl leading-7 text-gray-500 sm:mt-4">
                         Join us for a bunch of interesting talks!


### PR DESCRIPTION
I have added the ability to see the upcoming event in the user's local timezone. This is quite convenient. 

Also, I fixed a typo, so we now pull in alpinejs instead of alpine (log parser). 

You can simulate other timezones in devtools menu "more tools -> sensors"

![timezone](https://user-images.githubusercontent.com/312065/91219641-3fe00280-e71b-11ea-83bb-83623715e800.png)

Same event in Tokyo: 

![timezone2](https://user-images.githubusercontent.com/312065/91219657-453d4d00-e71b-11ea-9173-e369e41b4ebf.png)

